### PR TITLE
Move DNS updating into subcommand

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,5 +11,5 @@ else
     BUILD=zigbuild
 fi
 cargo ${BUILD} --release --target aarch64-unknown-linux-gnu
-scp target/aarch64-unknown-linux-gnu/release/digitalocean-dyn-dns gilneas:~
-ssh gilneas -- "chmod +x ~/digitalocean-dyn-dns && sudo mv ~/digitalocean-dyn-dns /usr/local/bin/digitalocean-dyn-dns && sudo systemctl restart digitalocean-dyn-dns.service"
+scp digitalocean-dyn-dns.service target/aarch64-unknown-linux-gnu/release/digitalocean-dyn-dns gilneas:~
+ssh gilneas -- "chmod +x ~/digitalocean-dyn-dns && sudo mv ~/digitalocean-dyn-dns /usr/local/bin/digitalocean-dyn-dns && sudo mv ~/digitalocean-dyn-dns.service  /etc/systemd/system/digitalocean-dyn-dns.service; sudo systemctl daemon-reload && sudo systemctl restart digitalocean-dyn-dns.service"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,14 +7,24 @@ use crate::ip_retriever;
 
 #[derive(Debug)]
 pub struct Args {
-    pub record: String,
-    pub domain: String,
     pub token: String,
     pub ip: IpAddr,
-    pub rtype: String,
-    pub ttl: u16,
     pub quiet: bool,
     pub dry_run: bool,
+    pub subcmd_args: SubcmdArgs,
+}
+
+#[derive(Debug)]
+pub enum SubcmdArgs {
+    Dns(DnsArgs),
+}
+
+#[derive(Debug)]
+pub struct DnsArgs {
+    pub record: String,
+    pub domain: String,
+    pub rtype: String,
+    pub ttl: u16,
 }
 
 impl Args {
@@ -22,18 +32,6 @@ impl Args {
         let matches = clap::Command::new(crate_name!())
             .version(crate_version!())
             .author("Chris Lieb")
-            .arg(
-                clap::Arg::new("RECORD")
-                    .required(true)
-                    .num_args(1)
-                    .help("The DNS record within the domain to update"),
-            )
-            .arg(
-                clap::Arg::new("DOMAIN")
-                    .required(true)
-                    .num_args(1)
-                    .help("The domain that has the record to update"),
-            )
             .arg(
                 clap::Arg::new("token")
                     .short('t')
@@ -59,22 +57,6 @@ impl Args {
                     .help("Use this IP address when updating the record"),
             )
             .arg(
-                clap::Arg::new("rtype")
-                    .long("rtype")
-                    .num_args(1)
-                    .value_parser(["A", "AAAA"])
-                    .default_value("A")
-                    .help("The type of DNS record to set"),
-            )
-            .arg(
-                clap::Arg::new("ttl")
-                    .long("ttl")
-                    .num_args(1)
-                    .default_value("60")
-                    .value_parser(clap::value_parser!(u16))
-                    .help("The TTL for the new DNS record"),
-            )
-            .arg(
                 clap::Arg::new("quiet")
                     .short('q')
                     .long("quiet")
@@ -88,11 +70,42 @@ impl Args {
                     .num_args(0)
                     .help("Do everything except actually set the record"),
             )
+            .subcommand(
+                clap::Command::new("dns")
+                    .arg(
+                        clap::Arg::new("RECORD")
+                            .required(true)
+                            .num_args(1)
+                            .help("The DNS record within the domain to update"),
+                    )
+                    .arg(
+                        clap::Arg::new("DOMAIN")
+                            .required(true)
+                            .num_args(1)
+                            .help("The domain that has the record to update"),
+                    )
+                    .arg(
+                        clap::Arg::new("rtype")
+                            .long("rtype")
+                            .num_args(1)
+                            .value_parser(["A", "AAAA"])
+                            .default_value("A")
+                            .help("The type of DNS record to set"),
+                    )
+                    .arg(
+                        clap::Arg::new("ttl")
+                            .long("ttl")
+                            .num_args(1)
+                            .default_value("60")
+                            .value_parser(clap::value_parser!(u16))
+                            .help("The TTL for the new DNS record"),
+                    ),
+            )
+            .subcommand_required(true)
             .get_matches();
 
         let literal_ip = matches.get_one::<IpAddr>("ip");
         let local = matches.get_flag("local");
-        let rtype = matches.get_one::<String>("rtype").unwrap().clone();
 
         let ip = if let Some(lit) = literal_ip {
             info!("Using user-provided IP address: {}", lit);
@@ -102,26 +115,38 @@ impl Args {
             ip_retriever::get_local_ip().expect("Unable to retrieve local IP address")
         } else {
             info!("Getting public IP address of machine...");
-            let ip =
-                ip_retriever::get_external_ip().expect("Unable to retrieve external IP address");
-            if (ip.is_ipv4() && rtype != "A") || (ip.is_ipv6() && rtype != "AAAA") {
-                panic!("Expected Rtype {rtype} but got {ip:?}")
-            }
-            ip
+            ip_retriever::get_external_ip().expect("Unable to retrieve external IP address")
         };
         info!("Will publish IP address: {:?}", ip);
 
+        let subcmd_args = match matches.subcommand() {
+            Some(("dns", sub_match)) => {
+                let rtype = sub_match.get_one::<String>("rtype").unwrap().clone();
+                if (ip.is_ipv4() && rtype != "A") || (ip.is_ipv6() && rtype != "AAAA") {
+                    panic!("Expected Rtype {rtype} but got {ip:?}")
+                }
+
+                SubcmdArgs::Dns(DnsArgs {
+                    record: sub_match.get_one::<String>("RECORD").unwrap().clone(),
+                    domain: sub_match.get_one::<String>("DOMAIN").unwrap().clone(),
+                    rtype,
+                    ttl: *sub_match
+                        .get_one::<u16>("ttl")
+                        .expect("Must provide integer for ttl"),
+                })
+            }
+            // these situations should be impossible, but Rust can't tell since the subcommand
+            // matches are stringly-typed and it can't tell that we require a subcommand
+            Some((cmd, _)) => panic!("Unknown subcommand detected: {}", cmd),
+            None => panic!("No subcommand specified"),
+        };
+
         Args {
-            record: matches.get_one::<String>("RECORD").unwrap().clone(),
-            domain: matches.get_one::<String>("DOMAIN").unwrap().clone(),
             token: matches.get_one::<String>("token").unwrap().clone(),
             ip,
-            rtype,
-            ttl: *matches
-                .get_one::<u16>("ttl")
-                .expect("Must provide integer for ttl"),
             quiet: matches.get_flag("quiet"),
             dry_run: matches.get_flag("dry_run"),
+            subcmd_args,
         }
     }
 }

--- a/src/digitalocean.rs
+++ b/src/digitalocean.rs
@@ -19,6 +19,7 @@ pub trait DigitalOceanClient {
         domain: &str,
         record: &DomainRecord,
         value: &IpAddr,
+        ttl: &u16,
         dry_run: &bool,
     ) -> Result<DomainRecord, Error>;
 
@@ -28,6 +29,7 @@ pub trait DigitalOceanClient {
         record: &str,
         rtype: &str,
         value: &IpAddr,
+        ttl: &u16,
         dry_run: &bool,
     ) -> Result<DomainRecord, Error>;
 }
@@ -136,6 +138,7 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
         domain: &str,
         record: &DomainRecord,
         value: &IpAddr,
+        ttl: &u16,
         dry_run: &bool,
     ) -> Result<DomainRecord, Error> {
         if *dry_run {
@@ -150,7 +153,7 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
                 data: "".to_string(),
                 priority: None,
                 port: None,
-                ttl: 0,
+                ttl: *ttl,
                 weight: None,
                 flags: None,
                 tag: None,
@@ -187,6 +190,7 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
         record: &str,
         rtype: &str,
         value: &IpAddr,
+        ttl: &u16,
         dry_run: &bool,
     ) -> Result<DomainRecord, Error> {
         if *dry_run {
@@ -201,7 +205,7 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
                 data: "".to_string(),
                 priority: None,
                 port: None,
-                ttl: 0,
+                ttl: *ttl,
                 weight: None,
                 flags: None,
                 tag: None,
@@ -747,7 +751,7 @@ mod test {
                         "data": "2.3.4.5",
                         "priority": null,
                         "port": null,
-                        "ttl": 100,
+                        "ttl": 60,
                         "weight": null,
                         "flags": null,
                         "tag": null
@@ -774,6 +778,7 @@ mod test {
                 &"google.com".to_string(),
                 &orig_record,
                 &Ipv4Addr::new(2, 3, 4, 5).into(),
+                &60,
                 &false,
             );
         assert_eq!(
@@ -784,7 +789,7 @@ mod test {
                 data: "2.3.4.5".to_string(),
                 priority: None,
                 port: None,
-                ttl: 100,
+                ttl: 60,
                 weight: None,
                 flags: None,
                 tag: None
@@ -823,7 +828,7 @@ mod test {
                         "data": "1.2.3.4",
                         "priority": null,
                         "port": null,
-                        "ttl": 60,
+                        "ttl": 100,
                         "weight": null,
                         "flags": null,
                         "tag": null
@@ -839,6 +844,7 @@ mod test {
                 &"foo".to_string(),
                 &"A".to_string(),
                 &Ipv4Addr::new(1, 2, 3, 4).into(),
+                &100,
                 &false,
             );
         assert_eq!(
@@ -849,7 +855,7 @@ mod test {
                 data: "1.2.3.4".to_string(),
                 priority: None,
                 port: None,
-                ttl: 60,
+                ttl: 100,
                 weight: None,
                 flags: None,
                 tag: None

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ fn main() {
             dns_args.record,
             dns_args.rtype,
             args.ip,
+            dns_args.ttl,
             args.dry_run,
         )
         .expect("Encountered error while updating DNS record"),
@@ -67,6 +68,7 @@ fn run_dns(
     record_name: String,
     rtype: String,
     ip: IpAddr,
+    ttl: u16,
     dry_run: bool,
 ) -> Result<DomainRecord, Error> {
     client.get_domain(&domain)?.ok_or(Error::DomainNotFound())?;
@@ -84,7 +86,7 @@ fn run_dns(
                     "Will update record_name {}.{} ({}) to {}",
                     record_name, domain, rtype, ip
                 );
-                let record = client.update_record(&domain, &record, &ip, &dry_run)?;
+                let record = client.update_record(&domain, &record, &ip, &ttl, &dry_run)?;
                 info!("Successfully updated record!");
                 Ok(record)
             }
@@ -94,7 +96,8 @@ fn run_dns(
                 "Will create new record {}.{} ({}) -> {}",
                 record_name, domain, rtype, ip
             );
-            let record = client.create_record(&domain, &record_name, &rtype, &ip, &dry_run)?;
+            let record =
+                client.create_record(&domain, &record_name, &rtype, &ip, &ttl, &dry_run)?;
             info!("Successfully created new record! ({})", record.id);
             Ok(record)
         }
@@ -161,6 +164,7 @@ mod test {
             record_name.clone(),
             rtype.clone(),
             ip_addr.clone(),
+            60,
             false,
         );
 
@@ -210,6 +214,7 @@ mod test {
             record_name.clone(),
             rtype.clone(),
             new_ip_addr.clone(),
+            60,
             false,
         );
 
@@ -259,6 +264,7 @@ mod test {
             record_name.clone(),
             rtype.clone(),
             new_ip_addr.clone(),
+            60,
             false,
         );
 
@@ -338,6 +344,7 @@ mod test {
             _: &str,
             record: &DomainRecord,
             value: &IpAddr,
+            ttl: &u16,
             _dry_run: &bool,
         ) -> Result<DomainRecord, Error> {
             if self.update_record_is_ok {
@@ -348,7 +355,7 @@ mod test {
                     data: (*value).to_string(),
                     priority: None,
                     port: None,
-                    ttl: record.ttl.clone(),
+                    ttl: *ttl,
                     weight: None,
                     flags: None,
                     tag: None,
@@ -364,6 +371,7 @@ mod test {
             record: &str,
             rtype: &str,
             value: &IpAddr,
+            ttl: &u16,
             _dry_run: &bool,
         ) -> Result<DomainRecord, Error> {
             if self.create_record_is_ok {
@@ -374,7 +382,7 @@ mod test {
                     data: (*value).to_string(),
                     priority: None,
                     port: None,
-                    ttl: 60,
+                    ttl: *ttl,
                     weight: None,
                     flags: None,
                     tag: None,


### PR DESCRIPTION
In preparation for adding the ability to also apply dynamic IPs to firewall rules, move the DNS updating into a subcommand.  Also, adds support for the `--ttl` option, which was previously present in the parser but not respected in the code.